### PR TITLE
add move_group parameter to MoveGroup class

### DIFF
--- a/src/moveit_python/move_group_interface.py
+++ b/src/moveit_python/move_group_interface.py
@@ -42,10 +42,10 @@ class MoveGroupInterface(object):
     ## @param frame Name of the fixed frame in which planning happens
     ## @param listener A TF listener instance (optional, will create a new one if None)
     ## @param plan_only Should we only plan, but not execute?
-    def __init__(self, group, frame, listener=None, plan_only=False):
+    def __init__(self, group, frame, move_group="move_group", listener=None, plan_only=False):
         self._group = group
         self._fixed_frame = frame
-        self._action = actionlib.SimpleActionClient('move_group',
+        self._action = actionlib.SimpleActionClient(move_group,
                                                     MoveGroupAction)
         self._action.wait_for_server()
         if listener == None:

--- a/src/moveit_python/move_group_interface.py
+++ b/src/moveit_python/move_group_interface.py
@@ -40,6 +40,7 @@ class MoveGroupInterface(object):
     ## @brief Constructor for this utility
     ## @param group Name of the MoveIt! group to command
     ## @param frame Name of the fixed frame in which planning happens
+    ## @param move_group Name of the action server
     ## @param listener A TF listener instance (optional, will create a new one if None)
     ## @param plan_only Should we only plan, but not execute?
     def __init__(self, group, frame, move_group="move_group", listener=None, plan_only=False):


### PR DESCRIPTION
# Problem
If I create a namespace of node, `'move_group'`, the 1st argument of `actionlib.SimpleActionClient`, doesn't work because of the lack of `/` before the name.

# Solution
Therefore, I added the parameter `move_group` which default value is `'move_group'` to `MoveGroupInterface` class.

As a result of this change, we can create a namespace to our node.