### PR TITLE
Fixed error message when removing attached object.

### DIFF
--- a/src/moveit_python/planning_scene_interface.py
+++ b/src/moveit_python/planning_scene_interface.py
@@ -109,6 +109,7 @@ class PlanningSceneInterface(object):
     def sendUpdate(self, collision_object, attached_collision_object, use_service=True):
         ps = PlanningScene()
         ps.is_diff = True
+        ps.robot_state.is_diff = True
         if collision_object:
             ps.world.collision_objects.append(collision_object)
 


### PR DESCRIPTION
When calling `scene.removeAttachedObject("box")` the system gives the following error:

> This creates the following error: The specified RobotState is not marked as is_diff. The request to modify the object 'box' is not supported. Object is ignored.

This was because the `ps.robot_state.is_diff = True` wasn't set.

Also properly fixes the closed issue #19.

This thread was of help: https://github.com/ros-planning/moveit_ros/issues/323

Also I think this comment is relevant: https://github.com/ros-planning/moveit_tutorials/issues/98#issuecomment-504145401