### PR TITLE
Fixed a comparison and logical statement order issue.

### DIFF
--- a/src/moveit_python/pick_place_interface.py
+++ b/src/moveit_python/pick_place_interface.py
@@ -298,10 +298,10 @@ class PickPlaceInterface(object):
                 rospy.logerr("Place failed in planning stage, try again...")
                 rospy.sleep(0.5)  # short sleep to let state settle a bit?
                 continue
-            elif scene and \
-                 place_result.error_code.val == MoveItErrorCodes.CONTROL_FAILED or \
+            elif not scene == None and \
+                 (place_result.error_code.val == MoveItErrorCodes.CONTROL_FAILED or \
                  place_result.error_code.val == MoveItErrorCodes.MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE or \
-                 place_result.error_code.val == MoveItErrorCodes.TIMED_OUT:
+                 place_result.error_code.val == MoveItErrorCodes.TIMED_OUT):
                 rospy.logerr("Place failed during execution, attempting to cleanup.")
                 if name in scene.getKnownAttachedObjects():
                     rospy.loginfo("Place did not place object, approach must have failed, will retry...")

--- a/src/moveit_python/pick_place_interface.py
+++ b/src/moveit_python/pick_place_interface.py
@@ -260,10 +260,10 @@ class PickPlaceInterface(object):
                 rospy.logerr("Pick failed in the planning stage, try again...")
                 rospy.sleep(0.5)  # short sleep to try and let state settle a bit?
                 continue
-            elif scene and \
-                pick_result.error_code.val == MoveItErrorCodes.CONTROL_FAILED or \
+            elif not scene == None and \
+                (pick_result.error_code.val == MoveItErrorCodes.CONTROL_FAILED or \
                 pick_result.error_code.val == MoveItErrorCodes.MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE or \
-                pick_result.error_code.val == MoveItErrorCodes.TIMED_OUT:
+                pick_result.error_code.val == MoveItErrorCodes.TIMED_OUT):
                 rospy.logerr("Pick failed during execution, attempting to cleanup.")
                 if name in scene.getKnownAttachedObjects():
                     rospy.loginfo("Pick managed to grab object, retreat must have failed, continuing anyways")

--- a/src/moveit_python/planning_scene_interface.py
+++ b/src/moveit_python/planning_scene_interface.py
@@ -109,6 +109,7 @@ class PlanningSceneInterface(object):
     def sendUpdate(self, collision_object, attached_collision_object, use_service=True):
         ps = PlanningScene()
         ps.is_diff = True
+        ps.robot_state.is_diff = True
         if collision_object:
             ps.world.collision_objects.append(collision_object)
 


### PR DESCRIPTION
The `scene` parameter is `None` by default, this is not equal to `0` or `False`, therefore it passed the comparison anyway and gave the following error:

>   File "/home/karl/catkin_ws/src/moveit_python/src/moveit_python/pick_place_interface.py", line 268, in pick_with_retry
    if name in scene.getKnownAttachedObjects():
AttributeError: 'NoneType' object has no attribute 'getKnownAttachedObjects'

Second problem in there was the logical statement order, as [`or` precedes `and`](https://docs.python.org/3/reference/expressions.html#operator-precedence). So even when fixing the `scene` parameter comparison with `None` it passed this block and threw the same error. I added parenthesis as a quick solution.