### PR TITLE
fix pyassimp indices bug

### DIFF
--- a/src/moveit_python/planning_scene_interface.py
+++ b/src/moveit_python/planning_scene_interface.py
@@ -147,10 +147,16 @@ class PlanningSceneInterface(object):
         mesh = Mesh()
         for face in scene.meshes[0].faces:
             triangle = MeshTriangle()
-            if len(face.indices) == 3:
-                triangle.vertex_indices = [face.indices[0],
-                                           face.indices[1],
-                                           face.indices[2]]
+            if hasattr(face, 'indices'):
+                if len(face.indices) == 3:
+                    triangle.vertex_indices = [face.indices[0],
+                                               face.indices[1],
+                                               face.indices[2]]
+            else:
+                if len(face) == 3:
+                    triangle.vertex_indices = [face[0],
+                                               face[1],
+                                               face[2]]
             mesh.triangles.append(triangle)
         for vertex in scene.meshes[0].vertices:
             point = Point()


### PR DESCRIPTION
`pyassimp>=3.4.0` returns `numpy.ndarray` for `scene.meshes[0].face`, which causes error on kinetic and melodic
https://github.com/ros-planning/moveit/issues/86#issuecomment-263759173
https://github.com/ros-planning/moveit/pull/450