### PR TITLE
fix: Add `attached_object_touch_links` for pickup

### DIFF
--- a/src/moveit_python/pick_place_interface.py
+++ b/src/moveit_python/pick_place_interface.py
@@ -77,6 +77,7 @@ class PickPlaceInterface(object):
     def pickup(self, name, grasps, wait=True, **kwargs):
         # Check arguments
         supported_args = ("allow_gripper_support_collision",
+                          "attached_object_touch_links",
                           "allowed_touch_objects",
                           "plan_only",
                           "planner_id",


### PR DESCRIPTION
With the current implementation it is not possible to add links to the allowed `attached_object_touch_links` list. It is queried [here on line 119](https://github.com/mikeferguson/moveit_python/blob/78242dba4349ca00bd94fadecf60be4350777f95/src/moveit_python/pick_place_interface.py#L119) but is not in the `supported_args` list.

To be able to add for example gripper links to the `attached_object_touch_links` list, the string should be added to the `supported_args` list. This PR adds this string. Thanks for this otherwise great repository, your effort and for adding this to the `ros1` branch. :)